### PR TITLE
refactor(site): use next-themes for theme switching

### DIFF
--- a/site/bun.lock
+++ b/site/bun.lock
@@ -8,6 +8,7 @@
         "@tanstack/react-table": "^8.21.3",
         "lucide-react": "^1.24.0",
         "next": "16.2.10",
+        "next-themes": "^0.4.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
       },
@@ -618,6 +619,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-exports-info": ["node-exports-info@1.6.2", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-table": "^8.21.3",
     "lucide-react": "^1.24.0",
     "next": "16.2.10",
+    "next-themes": "^0.4.6",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type {Metadata} from "next";
-import Script from "next/script";
+import {ThemeProvider} from "next-themes";
 import type {ReactNode} from "react";
 import "./globals.css";
 
@@ -35,28 +35,27 @@ export const metadata: Metadata = {
   robots: {index: true, follow: true},
 };
 
-const themeScript = `
-  try {
-    var savedTheme = localStorage.getItem("internships-theme");
-    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    document.documentElement.dataset.theme = savedTheme || (prefersDark ? "dark" : "light");
-  } catch (_) {}
-`;
-
 export default function RootLayout({children}: Readonly<{children: ReactNode}>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <Script id="theme-init" strategy="beforeInteractive">
-          {themeScript}
-        </Script>
         <script
           defer
           src="https://cloud.umami.is/script.js"
           data-website-id="e3733fba-21a0-4663-9e54-9e6adab3e0d5"
         />
       </head>
-      <body>{children}</body>
+      <body>
+        <ThemeProvider
+          attribute="data-theme"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+          storageKey="internships-theme"
+        >
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/site/src/components/theme/theme-toggle.tsx
+++ b/site/src/components/theme/theme-toggle.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import {useTheme} from "next-themes";
+
 function ThemeIcon() {
   return (
     <span className="theme-icon" aria-hidden="true">
@@ -15,15 +17,10 @@ function ThemeIcon() {
 }
 
 export function ThemeToggle() {
+  const {resolvedTheme, setTheme} = useTheme();
+
   function toggleTheme() {
-    const root = document.documentElement;
-    const nextTheme = root.dataset.theme === "dark" ? "light" : "dark";
-    root.dataset.theme = nextTheme;
-    try {
-      localStorage.setItem("internships-theme", nextTheme);
-    } catch {
-      // The visual toggle still works when storage is blocked by browser policy.
-    }
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
   }
 
   return (


### PR DESCRIPTION
This replaces the custom theme implementation with next-themes to avoid flashing on initial load and animations when switching themes